### PR TITLE
Lutris 6.4 Star Ciziten Fixes #78

### DIFF
--- a/dlls/advapi32/advapi32.spec
+++ b/dlls/advapi32/advapi32.spec
@@ -603,7 +603,7 @@
 @ stdcall -import QueryServiceObjectSecurity(long long ptr long ptr)
 @ stdcall -import QueryServiceStatus(long ptr)
 @ stdcall -import QueryServiceStatusEx (long long ptr long ptr)
-# @ stub QueryTraceA
+@ stdcall QueryTraceA(int64 str ptr)
 @ stdcall QueryTraceW(int64 wstr ptr)
 # @ stub QueryUserServiceName
 # @ stub QueryUsersOnEncryptedFile

--- a/dlls/advapi32/eventlog.c
+++ b/dlls/advapi32/eventlog.c
@@ -674,6 +674,15 @@ ULONG WINAPI StopTraceA( TRACEHANDLE session, LPCSTR session_name, PEVENT_TRACE_
 }
 
 /******************************************************************************
+ * QueryTraceA [ADVAPI32.@]
+ */
+ULONG WINAPI QueryTraceA( TRACEHANDLE handle, LPCSTR sessionname, PEVENT_TRACE_PROPERTIES properties )
+{
+    FIXME("%s %s %p: stub\n", wine_dbgstr_longlong(handle), debugstr_a(sessionname), properties);
+    return ERROR_WMI_INSTANCE_NOT_FOUND;
+}
+
+/******************************************************************************
  * QueryTraceW [ADVAPI32.@]
  */
 ULONG WINAPI QueryTraceW( TRACEHANDLE handle, LPCWSTR sessionname, PEVENT_TRACE_PROPERTIES properties )

--- a/dlls/api-ms-win-eventing-legacy-l1-1-0/api-ms-win-eventing-legacy-l1-1-0.spec
+++ b/dlls/api-ms-win-eventing-legacy-l1-1-0/api-ms-win-eventing-legacy-l1-1-0.spec
@@ -6,7 +6,7 @@
 @ stdcall FlushTraceW(int64 wstr ptr) advapi32.FlushTraceW
 @ stdcall -ret64 OpenTraceA(ptr) advapi32.OpenTraceA
 @ stdcall QueryAllTracesA(ptr long ptr) advapi32.QueryAllTracesA
-@ stub QueryTraceA
+@ stdcall QueryTraceA(int64 str ptr) advapi32.QueryTraceA
 @ stdcall QueryTraceW(int64 wstr ptr) advapi32.QueryTraceW
 @ stdcall StartTraceA(ptr str ptr) advapi32.StartTraceA
 @ stdcall StopTraceA(int64 str ptr) advapi32.StopTraceA

--- a/dlls/mountmgr.sys/device.c
+++ b/dlls/mountmgr.sys/device.c
@@ -1838,6 +1838,19 @@ static NTSTATUS query_property( struct disk_device *device, IRP *irp )
 
         break;
     }
+    case StorageDeviceSeekPenaltyProperty:
+    {
+        DEVICE_SEEK_PENALTY_DESCRIPTOR *descriptor;
+        FIXME( "Faking StorageDeviceSeekPenaltyProperty data with no penalty\n" );
+        memset( irp->AssociatedIrp.SystemBuffer, 0, irpsp->Parameters.DeviceIoControl.OutputBufferLength );
+        descriptor = irp->AssociatedIrp.SystemBuffer;
+        descriptor->Version = sizeof(DEVICE_SEEK_PENALTY_DESCRIPTOR);
+        descriptor->Size = sizeof(DEVICE_SEEK_PENALTY_DESCRIPTOR);
+        descriptor->IncursSeekPenalty = FALSE;
+        status = STATUS_SUCCESS;
+        irp->IoStatus.Information = sizeof(DEVICE_SEEK_PENALTY_DESCRIPTOR);
+        break;
+    }
     default:
         FIXME( "Unsupported property %#x\n", query->PropertyId );
         status = STATUS_NOT_SUPPORTED;

--- a/include/ntddstor.h
+++ b/include/ntddstor.h
@@ -214,7 +214,8 @@ typedef enum _STORAGE_QUERY_TYPE {
 
 typedef enum _STORAGE_PROPERTY_ID {
     StorageDeviceProperty = 0,
-    StorageAdapterProperty
+    StorageAdapterProperty = 1,
+    StorageDeviceSeekPenaltyProperty = 7,
 } STORAGE_PROPERTY_ID, *PSTORAGE_PROPERTY_ID;
 
 typedef struct _STORAGE_PROPERTY_QUERY {
@@ -271,6 +272,12 @@ typedef struct _STORAGE_ADAPTER_DESCRIPTOR {
     USHORT                      BusMajorVersion;
     USHORT                      BusMinorVersion;
 } STORAGE_ADAPTER_DESCRIPTOR, *PSTORAGE_ADAPTER_DESCRIPTOR;
+
+typedef struct _DEVICE_SEEK_PENALTY_DESCRIPTOR {
+    ULONG                       Version;
+    ULONG                       Size;
+    BOOLEAN                     IncursSeekPenalty;
+} DEVICE_SEEK_PENALTY_DESCRIPTOR, *PDEVICE_SEEK_PENALTY_DESCRIPTOR;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
These two functions are needed for the new StarCitizen version 3.13 to work. One patch was merged in from mainline WINE 6.7, and the other is a candidate currently waiting to be included in mainline WINE.