### PR TITLE
Apply Upstream Commit: windowscodecs: BitmapScaler_CopyPixels: Do not demand a larger buffer than necessary. 

### DIFF
--- a/dlls/windowscodecs/scaler.c
+++ b/dlls/windowscodecs/scaler.c
@@ -251,7 +251,7 @@ static HRESULT WINAPI BitmapScaler_CopyPixels(IWICBitmapScaler *iface,
         goto end;
     }
 
-    if ((cbStride * dest_rect.Height) > cbBufferSize)
+    if (cbStride * (dest_rect.Height - 1) + bytesperrow > cbBufferSize)
     {
         hr = E_INVALIDARG;
         goto end;

--- a/dlls/windowscodecs/tests/bitmap.c
+++ b/dlls/windowscodecs/tests/bitmap.c
@@ -1151,7 +1151,7 @@ static void test_bitmap_scaler(void)
     double res_x, res_y;
     IWICBitmap *bitmap;
     UINT width, height;
-    BYTE buf[16];
+    BYTE buf[93];
     HRESULT hr;
 
     hr = IWICImagingFactory_CreateBitmap(factory, 4, 2, &GUID_WICPixelFormat24bppBGR, WICBitmapCacheOnLoad, &bitmap);
@@ -1243,7 +1243,7 @@ static void test_bitmap_scaler(void)
         WICBitmapInterpolationModeNearestNeighbor);
     ok(hr == E_INVALIDARG, "Failed to initialize bitmap scaler, hr %#x.\n", hr);
 
-    hr = IWICBitmapScaler_Initialize(scaler, (IWICBitmapSource *)bitmap, 8, 4,
+    hr = IWICBitmapScaler_Initialize(scaler, (IWICBitmapSource *)bitmap, 7, 4,
         WICBitmapInterpolationModeNearestNeighbor);
     ok(hr == S_OK, "Failed to initialize bitmap scaler, hr %#x.\n", hr);
 
@@ -1251,20 +1251,20 @@ static void test_bitmap_scaler(void)
         WICBitmapInterpolationModeNearestNeighbor);
     ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
 
-    hr = IWICBitmapScaler_Initialize(scaler, (IWICBitmapSource *)bitmap, 8, 0,
+    hr = IWICBitmapScaler_Initialize(scaler, (IWICBitmapSource *)bitmap, 7, 0,
         WICBitmapInterpolationModeNearestNeighbor);
     ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
 
     hr = IWICBitmapScaler_Initialize(scaler, NULL, 8, 4, WICBitmapInterpolationModeNearestNeighbor);
     ok(hr == E_INVALIDARG, "Unexpected hr %#x.\n", hr);
 
-    hr = IWICBitmapScaler_Initialize(scaler, (IWICBitmapSource *)bitmap, 8, 4,
+    hr = IWICBitmapScaler_Initialize(scaler, (IWICBitmapSource *)bitmap, 7, 4,
         WICBitmapInterpolationModeNearestNeighbor);
     ok(hr == WINCODEC_ERR_WRONGSTATE, "Unexpected hr %#x.\n", hr);
 
     hr = IWICBitmapScaler_GetSize(scaler, &width, &height);
     ok(hr == S_OK, "Failed to get scaler size, hr %#x.\n", hr);
-    ok(width == 8, "Unexpected width %u.\n", width);
+    ok(width == 7, "Unexpected width %u.\n", width);
     ok(height == 4, "Unexpected height %u.\n", height);
 
     hr = IWICBitmapScaler_GetSize(scaler, NULL, &height);
@@ -1306,6 +1306,9 @@ static void test_bitmap_scaler(void)
     hr = IWICBitmapScaler_CopyPalette(scaler, palette);
     ok(hr == WINCODEC_ERR_PALETTEUNAVAILABLE, "Unexpected hr %#x.\n", hr);
     IWICPalette_Release(palette);
+
+    hr = IWICBitmapScaler_CopyPixels(scaler, NULL, /*cbStride=*/24, sizeof(buf), buf);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
 
     IWICBitmapScaler_Release(scaler);
 


### PR DESCRIPTION
[This commit](https://gitlab.winehq.org/wine/wine/-/commit/cdb9a2748ba62891bfcd342cb3da82c204f896d2) contains a bugfix related to bitmap scaling. It fixes the CopyPixels function rejecting parameters that are valid on windows, where the destination bitmap buffer doesn't include padding for the last scanline. This behavior is relied upon by DirectXTex's mipmap generation.

This commit fixes the black texture problem in BeamNG.drive reported in ValveSoftware/Proton#1237

This commit has just been merged into proton experimental bleeding-edge ([here](https://github.com/ValveSoftware/wine/commit/2bc7af1c492137772e68cad181fe21e094225dd6)).
